### PR TITLE
[iOS] Update Request Permissions Behaviour

### DIFF
--- a/ios/lib/ReactNativeCameraKit/CKCameraManager.m
+++ b/ios/lib/ReactNativeCameraKit/CKCameraManager.m
@@ -49,13 +49,10 @@ RCT_EXPORT_METHOD(checkDeviceCameraAuthorizationStatus:(RCTPromiseResolveBlock)r
 
 RCT_EXPORT_METHOD(requestDeviceCameraAuthorization:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject) {
-    __block NSString *mediaType = AVMediaTypeVideo;
     
-    [AVCaptureDevice requestAccessForMediaType:mediaType completionHandler:^(BOOL granted) {
-        if (resolve) {
-            resolve(@(granted));
-        }
-    }];
+    resolve(@(false));
+    
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
 }
 
 

--- a/ios/lib/ReactNativeCameraKit/CKGalleryManager.m
+++ b/ios/lib/ReactNativeCameraKit/CKGalleryManager.m
@@ -303,11 +303,10 @@ RCT_EXPORT_METHOD(checkDevicePhotosAuthorizationStatus:(RCTPromiseResolveBlock)r
 
 RCT_EXPORT_METHOD(requestDevicePhotosAuthorization:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject) {
-    [CKGalleryManager requestDeviceGalleryAuthorization:^(BOOL isAuthorized) {
-        if (resolve) {
-            resolve(@(isAuthorized));
-        }
-    }];
+    
+    resolve(@(false));
+    
+    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
 }
 
 


### PR DESCRIPTION
On iOS 8 and above, you can only prompt the user for access once per install.
This PR update the "requestDeviceCameraAuthorization" and "requestDevicePhotosAuthorization" function when called it jumps to app settings where the user can activate the necessary permissions.

This PR already has #169 PR included.